### PR TITLE
feat: add /info/:id route for anime details

### DIFF
--- a/app/components/Cards.vue
+++ b/app/components/Cards.vue
@@ -24,7 +24,7 @@ onMounted(() => {
         </h1>
         <!-- Popular Section -->
         <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2 md:gap-4" v-if="category === 'Popular'">
-            <NuxtLink v-for="i in data?.popular.animes.slice(0, 36)" :key="i.id!" class="group">
+            <NuxtLink :to="`/info/${i.id}`" v-for="i in data?.popular.animes.slice(0, 36)" :key="i.id!" class="group">
                 <div class="space-y-2 transition-transform group-hover:-translate-y-1">
                     <div class="w-full h-60 md:h-80 lg:h-64">
                         <img :src="i.poster!" :alt="i.name!" class="w-full h-full rounded-xl object-cover">
@@ -35,7 +35,7 @@ onMounted(() => {
         </div>
         <!-- Trending Section -->
         <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2 md:gap-4" v-else-if="category === 'Trending'">
-            <NuxtLink v-for="i in data?.trending.animes.slice(0, 36)" :key="i.id!" class="group">
+            <NuxtLink :to="`/info/${i.id}`" v-for="i in data?.trending.animes.slice(0, 36)" :key="i.id!" class="group">
                 <div class="space-y-2 transition-transform group-hover:-translate-y-1">
                     <div class="w-full h-60 md:h-80 lg:h-64">
                         <img :src="i.poster!" :alt="i.name!" class="w-full h-full rounded-xl object-cover">

--- a/app/components/Genre.vue
+++ b/app/components/Genre.vue
@@ -16,7 +16,7 @@ onMounted(() => {
         <h1 class="text-2xl font-bold">{{ data.genreName.replace("Anime", "") }} Genre</h1>
         <!-- Genre Section -->
         <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2 md:gap-4">
-            <NuxtLink v-for="i in data.animes.slice(0, 30)" :key="i.id!" class="group">
+            <NuxtLink :to="`/info/${i.id}`" v-for="i in data.animes.slice(0, 30)" :key="i.id!" class="group">
                 <div class="space-y-2 transition-transform group-hover:-translate-y-1">
                     <div class="w-full h-60 md:h-80 lg:h-64">
                         <img :src="i.poster!" :alt="i.name!" class="w-full h-full rounded-xl object-cover">

--- a/app/components/Popular.vue
+++ b/app/components/Popular.vue
@@ -6,7 +6,7 @@ const { data } = await useFetch("/api/popular", { query: { page: 1 } });
     <div class="space-y-4 p-4 lg:p-0">
         <h1 class="text-2xl font-bold">Most Popular</h1>
         <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2 md:gap-4">
-            <NuxtLink v-for="(i, index) in data?.animes.slice(0, 6)" :key="i.id!"
+            <NuxtLink :to="`/info/${i.id}`" v-for="(i, index) in data?.animes.slice(0, 6)" :key="i.id!"
                 class="group rounded-xl transition-colors hover:bg-neutral-200 hover:dark:bg-neutral-800">
                 <div class="space-y-2 transition-transform group-hover:scale-90">
                     <div class="w-full h-60 md:h-80 lg:h-64">

--- a/app/components/Recent.vue
+++ b/app/components/Recent.vue
@@ -6,7 +6,7 @@ const { data } = await useFetch("/api/recent");
     <div class="space-y-4 p-4 lg:p-0">
         <h1 class="text-2xl font-bold">Latest Episodes</h1>
         <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2 md:gap-4">
-            <NuxtLink v-for="i in data?.animes.slice(0, 12)" :key="i.id!" class="group">
+            <NuxtLink :to="`/info/${i.id}`" v-for="i in data?.animes.slice(0, 12)" :key="i.id!" class="group">
                 <div class="space-y-2 transition-transform group-hover:-translate-y-1">
                     <div class="w-full h-60 md:h-80 lg:h-64">
                         <img :src="i.poster!" :alt="i.name!" class="w-full h-full rounded-xl object-cover">

--- a/app/components/Trending.vue
+++ b/app/components/Trending.vue
@@ -6,7 +6,7 @@ const { data } = await useFetch("/api/trending", { query: { page: 1 } });
     <div class="space-y-4 p-4 lg:p-0">
         <h1 class="text-2xl font-bold">Trending Now</h1>
         <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2 md:gap-4">
-            <NuxtLink v-for="i in data?.animes.slice(0, 12)" :key="i.id!" class="group">
+            <NuxtLink :to="`/info/${i.id}`" v-for="i in data?.animes.slice(0, 12)" :key="i.id!" class="group">
                 <div class="space-y-2 transition-transform group-hover:-translate-y-1">
                     <div class="w-full h-60 md:h-80 lg:h-64">
                         <img :src="i.poster!" :alt="i.name!" class="w-full h-full rounded-xl object-cover">

--- a/app/pages/info/[id].vue
+++ b/app/pages/info/[id].vue
@@ -1,0 +1,6 @@
+<script lang="ts" setup>
+const { id } = useRoute().params
+</script>
+
+<template>
+</template>

--- a/app/pages/info/[id].vue
+++ b/app/pages/info/[id].vue
@@ -1,6 +1,66 @@
 <script lang="ts" setup>
 const { id } = useRoute().params
+const { data } = await useFetch("/api/info", { query: { id } });
+
+const toKebabCase = (genre: string) => {
+    return genre.trim().toLowerCase().replace(/\s+/g, "-");
+}
 </script>
 
 <template>
+    <Head>
+        <Title>Aniryuu - {{ data?.anime.info.name }}</Title>
+    </Head>
+    <div class="space-y-4 p-4 lg:p-0">
+        <div class="grid grid-cols-1 md:grid-cols-4 lg:grid-cols-5 gap-4">
+            <div class="md:col-span-1 space-y-2">
+                <div class="w-1/2 md:w-full h-fit mx-auto">
+                    <img :src="data?.anime.info.poster!" :alt="data?.anime.info.name!"
+                        class="w-full h-full rounded-xl object-cover">
+                </div>
+                <div class="flex flex-col gap-2">
+                    <UButton icon="i-lucide-play" label="Watch Now" color="neutral" block disabled />
+                    <div class="grid grid-cols-2 gap-2">
+                        <UButton :to="`https://myanimelist.net/anime/${data?.anime.info.malId}`" target="_blank"
+                            label="MAL" variant="ghost" block :disabled="Boolean(!data?.anime.info.malId)" />
+                        <UButton :to="`https://anilist.co/anime/${data?.anime.info.anilistId}`" target="_blank"
+                            label="Anilist" variant="ghost" block :disabled="Boolean(!data?.anime.info.anilistId)" />
+                    </div>
+                </div>
+            </div>
+            <div class="md:col-span-3 lg:col-span-4 space-y-4">
+                <div class="space-y-2">
+                    <div class="flex flex-col">
+                        <h1 class="text-2xl font-bold">{{ data?.anime.info.name }}</h1>
+                        <p class="text-base font-medium opacity-75">{{ data?.anime.moreInfo.japanese }}</p>
+                    </div>
+                    <div class="flex flex-wrap items-center gap-2">
+                        <UBadge :label="String(data?.anime.info.stats.type)" color="neutral" variant="subtle"
+                            v-if="data?.anime.info.stats.type" />
+                        <UBadge :label="String(data?.anime.moreInfo.status)" color="neutral" variant="subtle"
+                            v-if="data?.anime.moreInfo.status" />
+                        <UBadge :label="String(data?.anime.moreInfo.premiered)" color="neutral" variant="subtle"
+                            v-if="data?.anime.moreInfo.premiered" />
+                        <UBadge :label="String(data?.anime.moreInfo.studios)" color="neutral" variant="subtle"
+                            v-if="data?.anime.moreInfo.studios" />
+                        <UBadge icon="i-lucide-star" :label="String(data?.anime.moreInfo.malscore!)" variant="subtle" />
+                    </div>
+                    <div class="flex flex-wrap items-center gap-2" v-if="data?.anime.moreInfo.genres?.length! > 0">
+                        <UButton :to="`/genre/${toKebabCase(genre)}/1`" :label="genre" variant="soft" size="sm"
+                            v-for="(genre, index) in data?.anime.moreInfo.genres" :key="index" />
+                    </div>
+                    <div v-html="data?.anime.info.description" />
+                </div>
+            </div>
+        </div>
+        <div class="space-y-2" v-if="data?.anime.info.charactersVoiceActors.length! > 0">
+            <h2 class="text-xl font-bold">Characters</h2>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-2">
+                <UAlert :title="i.character.name" :description="i.character.cast" color="neutral" variant="subtle"
+                    :avatar="{
+                        src: i.character.poster
+                    }" v-for="(i, index) in data?.anime.info.charactersVoiceActors" :key="index" />
+            </div>
+        </div>
+    </div>
 </template>

--- a/app/pages/info/index.vue
+++ b/app/pages/info/index.vue
@@ -1,0 +1,3 @@
+<script lang="ts" setup>
+navigateTo("/");
+</script>

--- a/server/api/info.get.ts
+++ b/server/api/info.get.ts
@@ -1,0 +1,7 @@
+import { HiAnime } from "aniwatch";
+
+export default defineEventHandler(async (event) => {
+    const { id } = getQuery(event);
+    const hianime = new HiAnime.Scraper();
+    return await hianime.getInfo(id as string);
+});


### PR DESCRIPTION
This update introduces the `/info/:id` route for displaying detailed information about a specific anime. Accessing `/info` without an **ID** will gracefully redirect users to the home page to ensure a smooth navigation experience.